### PR TITLE
Style tagline and remove contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,8 +15,10 @@
   <!-- Header -->
   <header class="bg-white/70 backdrop-blur-sm fixed w-full z-10 shadow-sm">
     <div class="container mx-auto px-6 py-4 flex justify-between items-center">
-      <h1 class="text-2xl font-bold text-indigo-600">SIPO</h1>
-      <p>Super Image Prompt Optimizer for GPT‑4o</p>
+      <div class="flex flex-col leading-tight">
+        <h1 class="text-2xl font-bold text-indigo-600">SIPO</h1>
+        <p class="text-sm text-gray-600 -mt-1">Super Image Prompt Optimizer for GPT‑4o</p>
+      </div>
       <nav class="space-x-6 text-gray-700 hidden sm:block">
         <a href="#features" class="hover:text-indigo-600 transition">Features</a>
         <a href="#how-it-works" class="hover:text-indigo-600 transition">How It Works</a>
@@ -113,7 +115,6 @@
   <footer class="bg-gray-800 text-gray-400 py-10">
     <div class="container mx-auto px-6 text-center">
       <p>&copy; 2025 SIPO. Crafted for visionary creators.</p>
-      <p class="mt-2"><a href="mailto:support@chatgpt.com" class="hover:text-white">support@chatgpt.com</a></p>
     </div>
   </footer>
 </body>


### PR DESCRIPTION
## Summary
- style tagline text under "SIPO" with a smaller font and grey color
- remove the `support@chatgpt.com` footer link

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68813f05134483319377fbdef1ccc149